### PR TITLE
Fixed rust examples

### DIFF
--- a/examples/rust-regex/src/lib.rs
+++ b/examples/rust-regex/src/lib.rs
@@ -1,9 +1,8 @@
-#![feature(allocator_api)]
-
 extern crate regex;
 
 use regex::Regex;
-use std::heap::{Alloc, Heap, Layout};
+use std::alloc;
+use std::alloc::Layout;
 use std::mem;
 use std::str;
 
@@ -40,7 +39,7 @@ pub extern "C" fn match_count(r: *mut Regex, str_ptr: *mut u8, len: usize) -> us
 pub extern "C" fn alloc(size: usize) -> *mut u8 {
     unsafe {
         let layout = Layout::from_size_align(size, mem::align_of::<u8>()).unwrap();
-        Heap.alloc(layout).unwrap()
+        alloc::alloc(layout)
     }
 }
 
@@ -48,6 +47,6 @@ pub extern "C" fn alloc(size: usize) -> *mut u8 {
 pub extern "C" fn dealloc(ptr: *mut u8, size: usize) {
     unsafe  {
         let layout = Layout::from_size_align(size, mem::align_of::<u8>()).unwrap();
-        Heap.dealloc(ptr, layout);
+        alloc::dealloc(ptr, layout);
     }
 }

--- a/examples/rust-string/src/lib.rs
+++ b/examples/rust-string/src/lib.rs
@@ -1,6 +1,5 @@
-#![feature(allocator_api)]
-
-use std::heap::{Alloc, Heap, Layout};
+use std::alloc;
+use std::alloc::Layout;
 use std::ffi::{CString};
 use std::mem;
 use std::os::raw::c_char;
@@ -33,7 +32,7 @@ pub extern "C" fn prepend_from_rust(ptr: *mut u8, len: usize) -> *const c_char {
 pub extern "C" fn alloc(size: usize) -> *mut u8 {
     unsafe {
         let layout = Layout::from_size_align(size, mem::align_of::<u8>()).unwrap();
-        Heap.alloc(layout).unwrap()
+        alloc::alloc(layout)
     }
 }
 
@@ -41,6 +40,6 @@ pub extern "C" fn alloc(size: usize) -> *mut u8 {
 pub extern "C" fn dealloc(ptr: *mut u8, size: usize) {
     unsafe  {
         let layout = Layout::from_size_align(size, mem::align_of::<u8>()).unwrap();
-        Heap.dealloc(ptr, layout);
+        alloc::dealloc(ptr, layout);
     }
 }


### PR DESCRIPTION
Rust 1.29 brings stable allocator API.
Outdated API removed from the rust stdlib.

I still can't compile "rust-regex" due to
"Error in command 'compile': Method code too large!"