### PR TITLE
Fix #28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 group 'asmble'
-version '0.4.0'
+version '0.4.1'
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
-    ext.asm_version = '6.2.1'
+    ext.kotlin_version = '1.3.50'
+    ext.asm_version = '7.1'
 
     repositories {
         mavenCentral()
@@ -20,7 +20,7 @@ buildscript {
 allprojects {
     apply plugin: 'java'
     group 'com.github.cretz.asmble'
-    version '0.4.0'
+    version '0.4.1'
 
     repositories {
         mavenCentral()

--- a/compiler/src/main/kotlin/asmble/compile/jvm/ByteBufferMem.kt
+++ b/compiler/src/main/kotlin/asmble/compile/jvm/ByteBufferMem.kt
@@ -24,7 +24,7 @@ open class ByteBufferMem(val direct: Boolean = true) : Mem {
     override fun init(func: Func, initial: Int) = func.popExpecting(memType).addInsns(
         // Set the limit to initial
         (initial * Mem.PAGE_SIZE).const,
-        forceFnType<ByteBuffer.(Int) -> Buffer>(ByteBuffer::limit).invokeVirtual(),
+        forceFnType<ByteBuffer.(Int) -> ByteBuffer>(ByteBuffer::limit).invokeVirtual(),
         TypeInsnNode(Opcodes.CHECKCAST, ByteBuffer::class.ref.asmName),
         // Set it to use little endian
         ByteOrder::LITTLE_ENDIAN.getStatic(),

--- a/compiler/src/main/kotlin/asmble/run/jvm/interpret/RunModule.kt
+++ b/compiler/src/main/kotlin/asmble/run/jvm/interpret/RunModule.kt
@@ -35,7 +35,7 @@ class RunModule(
         getter to setter
     }
 
-    @SuppressWarnings("UNCHECKED_CAST")
+    @Suppress("UNCHECKED_CAST")
     override fun <T> exportedMemory(field: String, memClass: Class<T>) =
         ctx.exportIndex(field, Node.ExternalKind.MEMORY)?.let { index ->
             require(index == 0 && memClass == ByteBuffer::class.java)


### PR DESCRIPTION
Bump dependencies, update `ByteBuffer` APIs to Java 9's, suppress warning properly

This issue fixes #28, but may drop support for JRE 8. I'm using JRE 11.